### PR TITLE
Fix Geist Sans font application

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -22,5 +22,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
+    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[var(--font-geist-sans)]">
       <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
         <h1 className="text-2xl font-bold text-blue-600 font-mono">Daniel Alvarez</h1>
         <p className="text-lg font-mono">Software Engineer</p>


### PR DESCRIPTION
## Summary
- ensure body uses the Geist Sans font via CSS variable
- fix Tailwind arbitrary font syntax on homepage

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f8af3018832ca6cf7c1fa76e6f31